### PR TITLE
feat: correctly handles screens by using theme values instead of CSS variables that are not supported in media queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ module.exports = {
 		},
 
 		// for tailwind
-+ autoprefixer: {},
-+ 'tailwindcss/nesting': {},
-+ tailwindcss: {},
++		autoprefixer: {},
++		'tailwindcss/nesting': {},
++		tailwindcss: {},
 	},
 }
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,11 @@
 /// for reference: https://github.com/mantinedev/mantine/blob/master/packages/%40mantine/core/src/core/MantineProvider/global.css
 
 /**
- * @typedef {import('@mantine/core').MantineThemeColorsOverride} MantineThemeColorsOverride
+ * @typedef {import('@mantine/core').MantineThemeOverride} MantineThemeOverride
  * @typedef {import('tailwindcss').Config} TailwindConfig
  */
 
-const { DEFAULT_THEME } = require("@mantine/core");
+const { DEFAULT_THEME, mergeMantineTheme } = require("@mantine/core");
 
 /**
  * @example
@@ -34,10 +34,16 @@ const { DEFAULT_THEME } = require("@mantine/core");
  *  presets: [tailwindPresetMantine({ mantineColors: mantineTheme.colors })],
  * };
  * ```
+ *
+ * @param {MantineThemeOverride} mantineTheme
  */
 module.exports = function tailwindPresetMantine({
-	mantineColors = DEFAULT_THEME.colors,
+	mantineTheme = DEFAULT_THEME,
 } = {}) {
+	const mergedTheme = mergeMantineTheme(DEFAULT_THEME, mantineTheme);
+	const mantineColors = mergedTheme.colors;
+	const mantineBreakpoints = mergedTheme.breakpoints;
+
 	/**
 	 * @type {TailwindConfig}
 	 */
@@ -47,11 +53,11 @@ module.exports = function tailwindPresetMantine({
 		theme: {
 			extend: {
 				screens: {
-					xs: "var(--mantine-breakpoint-xs)",
-					sm: "var(--mantine-breakpoint-sm)",
-					md: "var(--mantine-breakpoint-md)",
-					lg: "var(--mantine-breakpoint-lg)",
-					xl: "var(--mantine-breakpoint-xl)",
+					xs: mantineBreakpoints.xs,
+					sm: mantineBreakpoints.sm,
+					md: mantineBreakpoints.md,
+					lg: mantineBreakpoints.lg,
+					xl: mantineBreakpoints.xl,
 				},
 				fontFamily: {
 					DEFAULT: ["var(--mantine-font-family)"],

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,8 @@
 
 /**
  * @typedef {import('@mantine/core').MantineThemeColorsOverride} MantineThemeColorsOverride
+ * @typedef {import('@mantine/core').MantineColorShade} MantineColorShade
+ * @typedef {import('@mantine/core').MantinePrimaryShade} MantinePrimaryShade
  * @typedef {import('tailwindcss').Config} TailwindConfig
  */
 
@@ -34,9 +36,13 @@ const { DEFAULT_THEME } = require("@mantine/core");
  *  presets: [tailwindPresetMantine({ mantineColors: mantineTheme.colors })],
  * };
  * ```
+ *
+ * @param {MantineThemeColorsOverride} mantineColors
+ * @param {MantineColorShade | PartialObjectDeep<MantinePrimaryShade, {}> | undefined} mantinePrimaryShade
  */
 module.exports = function tailwindPresetMantine({
 	mantineColors = DEFAULT_THEME.colors,
+	mantinePrimaryShade = 6,
 } = {}) {
 	/**
 	 * @type {TailwindConfig}
@@ -121,42 +127,42 @@ module.exports = function tailwindPresetMantine({
 				},
 				colors: {
 					...generateColors(mantineColors),
-					...generatePrimaryColors(),
+					...generatePrimaryColors(mantinePrimaryShade),
 					...generateVariantSpecificColors(mantineColors),
 					...generateVariantSpecificPrimaryColors(),
 					...generateOtherTextColors(),
 				},
 				backgroundColor: {
 					...generateColors(mantineColors),
-					...generatePrimaryColors(),
+					...generatePrimaryColors(mantinePrimaryShade),
 					...generateVariantSpecificColors(mantineColors),
 					...generateVariantSpecificPrimaryColors(),
 					...generateOtherBackgroundColors(),
 				},
 				placeholderColor: {
 					...generateColors(mantineColors),
-					...generatePrimaryColors(),
+					...generatePrimaryColors(mantinePrimaryShade),
 					...generateVariantSpecificColors(mantineColors),
 					...generateVariantSpecificPrimaryColors(),
 					...generateOtherTextColors(),
 				},
 				ringColor: {
 					...generateColors(mantineColors),
-					...generatePrimaryColors(),
+					...generatePrimaryColors(mantinePrimaryShade),
 					...generateVariantSpecificColors(mantineColors),
 					...generateVariantSpecificPrimaryColors(),
 					...generateOtherBorderColors(),
 				},
 				divideColor: {
 					...generateColors(mantineColors),
-					...generatePrimaryColors(),
+					...generatePrimaryColors(mantinePrimaryShade),
 					...generateVariantSpecificColors(mantineColors),
 					...generateVariantSpecificPrimaryColors(),
 					...generateOtherBorderColors(),
 				},
 				borderColor: {
 					...generateColors(mantineColors),
-					...generatePrimaryColors(),
+					...generatePrimaryColors(mantinePrimaryShade),
 					...generateVariantSpecificColors(mantineColors),
 					...generateVariantSpecificPrimaryColors(),
 					...generateOtherBorderColors(),
@@ -203,7 +209,15 @@ function generateColors(mantineColors) {
 	return colors;
 }
 
-function generatePrimaryColors() {
+/**
+ * @param {MantineColorShade | PartialObjectDeep<MantinePrimaryShade, {}> | undefined} mantinePrimaryShade
+ */
+function generatePrimaryColors(mantinePrimaryShade = 6) {
+	const parsedMantinePrimaryShade =
+		typeof mantinePrimaryShade === "number"
+			? mantinePrimaryShade
+			: mantinePrimaryShade.light || mantinePrimaryShade.dark || 6;
+
 	const colors = {
 		primary: {
 			50: "var(--mantine-primary-color-0)",
@@ -216,7 +230,13 @@ function generatePrimaryColors() {
 			700: "var(--mantine-primary-color-7)",
 			800: "var(--mantine-primary-color-8)",
 			900: "var(--mantine-primary-color-9)",
-			DEFAULT: "var(--mantine-primary-color-6)",
+			light: mantinePrimaryShade && mantinePrimaryShade.light
+				? `var(--mantine-primary-color-${mantinePrimaryShade.light}-light)`
+				: undefined,
+			dark: mantinePrimaryShade && mantinePrimaryShade.dark
+				? `var(--mantine-primary-color-${mantinePrimaryShade.dark}-dark)`
+				: undefined,
+			DEFAULT: `var(--mantine-primary-color-${parsedMantinePrimaryShade})`,
 		},
 	};
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,6 @@
 
 /**
  * @typedef {import('@mantine/core').MantineThemeColorsOverride} MantineThemeColorsOverride
- * @typedef {import('@mantine/core').MantineColorShade} MantineColorShade
- * @typedef {import('@mantine/core').MantinePrimaryShade} MantinePrimaryShade
  * @typedef {import('tailwindcss').Config} TailwindConfig
  */
 
@@ -36,13 +34,9 @@ const { DEFAULT_THEME } = require("@mantine/core");
  *  presets: [tailwindPresetMantine({ mantineColors: mantineTheme.colors })],
  * };
  * ```
- *
- * @param {MantineThemeColorsOverride} mantineColors
- * @param {MantineColorShade | PartialObjectDeep<MantinePrimaryShade, {}> | undefined} mantinePrimaryShade
  */
 module.exports = function tailwindPresetMantine({
 	mantineColors = DEFAULT_THEME.colors,
-	mantinePrimaryShade = 6,
 } = {}) {
 	/**
 	 * @type {TailwindConfig}
@@ -127,42 +121,42 @@ module.exports = function tailwindPresetMantine({
 				},
 				colors: {
 					...generateColors(mantineColors),
-					...generatePrimaryColors(mantinePrimaryShade),
+					...generatePrimaryColors(),
 					...generateVariantSpecificColors(mantineColors),
 					...generateVariantSpecificPrimaryColors(),
 					...generateOtherTextColors(),
 				},
 				backgroundColor: {
 					...generateColors(mantineColors),
-					...generatePrimaryColors(mantinePrimaryShade),
+					...generatePrimaryColors(),
 					...generateVariantSpecificColors(mantineColors),
 					...generateVariantSpecificPrimaryColors(),
 					...generateOtherBackgroundColors(),
 				},
 				placeholderColor: {
 					...generateColors(mantineColors),
-					...generatePrimaryColors(mantinePrimaryShade),
+					...generatePrimaryColors(),
 					...generateVariantSpecificColors(mantineColors),
 					...generateVariantSpecificPrimaryColors(),
 					...generateOtherTextColors(),
 				},
 				ringColor: {
 					...generateColors(mantineColors),
-					...generatePrimaryColors(mantinePrimaryShade),
+					...generatePrimaryColors(),
 					...generateVariantSpecificColors(mantineColors),
 					...generateVariantSpecificPrimaryColors(),
 					...generateOtherBorderColors(),
 				},
 				divideColor: {
 					...generateColors(mantineColors),
-					...generatePrimaryColors(mantinePrimaryShade),
+					...generatePrimaryColors(),
 					...generateVariantSpecificColors(mantineColors),
 					...generateVariantSpecificPrimaryColors(),
 					...generateOtherBorderColors(),
 				},
 				borderColor: {
 					...generateColors(mantineColors),
-					...generatePrimaryColors(mantinePrimaryShade),
+					...generatePrimaryColors(),
 					...generateVariantSpecificColors(mantineColors),
 					...generateVariantSpecificPrimaryColors(),
 					...generateOtherBorderColors(),
@@ -209,15 +203,7 @@ function generateColors(mantineColors) {
 	return colors;
 }
 
-/**
- * @param {MantineColorShade | PartialObjectDeep<MantinePrimaryShade, {}> | undefined} mantinePrimaryShade
- */
-function generatePrimaryColors(mantinePrimaryShade = 6) {
-	const parsedMantinePrimaryShade =
-		typeof mantinePrimaryShade === "number"
-			? mantinePrimaryShade
-			: mantinePrimaryShade.light || mantinePrimaryShade.dark || 6;
-
+function generatePrimaryColors() {
 	const colors = {
 		primary: {
 			50: "var(--mantine-primary-color-0)",
@@ -230,13 +216,7 @@ function generatePrimaryColors(mantinePrimaryShade = 6) {
 			700: "var(--mantine-primary-color-7)",
 			800: "var(--mantine-primary-color-8)",
 			900: "var(--mantine-primary-color-9)",
-			light: mantinePrimaryShade && mantinePrimaryShade.light
-				? `var(--mantine-primary-color-${mantinePrimaryShade.light}-light)`
-				: undefined,
-			dark: mantinePrimaryShade && mantinePrimaryShade.dark
-				? `var(--mantine-primary-color-${mantinePrimaryShade.dark}-dark)`
-				: undefined,
-			DEFAULT: `var(--mantine-primary-color-${parsedMantinePrimaryShade})`,
+			DEFAULT: "var(--mantine-primary-color-6)",
 		},
 	};
 

--- a/src/index.js
+++ b/src/index.js
@@ -216,7 +216,7 @@ function generatePrimaryColors() {
 			700: "var(--mantine-primary-color-7)",
 			800: "var(--mantine-primary-color-8)",
 			900: "var(--mantine-primary-color-9)",
-			DEFAULT: "var(--mantine-primary-color-6)",
+			DEFAULT: "var(--mantine-primary-color-filled)",
 		},
 	};
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
 /// for reference: https://github.com/mantinedev/mantine/blob/master/packages/%40mantine/core/src/core/MantineProvider/global.css
 
 /**
- * @typedef {import('@mantine/core').MantineThemeOverride} MantineThemeOverride
+ * @typedef {import('@mantine/core').MantineThemeColorsOverride} MantineThemeColorsOverride
+ * @typedef {import('@mantine/core').MantineBreakpointsValues} MantineBreakpointsValues
  * @typedef {import('tailwindcss').Config} TailwindConfig
  */
 
@@ -35,14 +36,18 @@ const { DEFAULT_THEME, mergeMantineTheme } = require("@mantine/core");
  * };
  * ```
  *
- * @param {MantineThemeOverride} mantineTheme
+ * @param {MantineThemeColorsOverride} mantineColors
+ * @param {PartialObjectDeep<MantineBreakpointsValues, {}>} mantineBreakpoints
  */
 module.exports = function tailwindPresetMantine({
-	mantineTheme = DEFAULT_THEME,
+	mantineColors = DEFAULT_THEME.colors,
+	mantineBreakpoints = DEFAULT_THEME.breakpoints,
 } = {}) {
-	const mergedTheme = mergeMantineTheme(DEFAULT_THEME, mantineTheme);
-	const mantineColors = mergedTheme.colors;
-	const mantineBreakpoints = mergedTheme.breakpoints;
+	const { colors: mergedMantineColors, breakpoints: mergedMantineBreakpoints } =
+		mergeMantineTheme(DEFAULT_THEME, {
+			colors: mantineColors,
+			breakpoints: mantineBreakpoints,
+		});
 
 	/**
 	 * @type {TailwindConfig}
@@ -53,11 +58,11 @@ module.exports = function tailwindPresetMantine({
 		theme: {
 			extend: {
 				screens: {
-					xs: mantineBreakpoints.xs,
-					sm: mantineBreakpoints.sm,
-					md: mantineBreakpoints.md,
-					lg: mantineBreakpoints.lg,
-					xl: mantineBreakpoints.xl,
+					xs: mergedMantineBreakpoints.xs,
+					sm: mergedMantineBreakpoints.sm,
+					md: mergedMantineBreakpoints.md,
+					lg: mergedMantineBreakpoints.lg,
+					xl: mergedMantineBreakpoints.xl,
 				},
 				fontFamily: {
 					DEFAULT: ["var(--mantine-font-family)"],
@@ -126,44 +131,44 @@ module.exports = function tailwindPresetMantine({
 					DEFAULT: "var(--mantine-radius-default)",
 				},
 				colors: {
-					...generateColors(mantineColors),
+					...generateColors(mergedMantineColors),
 					...generatePrimaryColors(),
-					...generateVariantSpecificColors(mantineColors),
+					...generateVariantSpecificColors(mergedMantineColors),
 					...generateVariantSpecificPrimaryColors(),
 					...generateOtherTextColors(),
 				},
 				backgroundColor: {
-					...generateColors(mantineColors),
+					...generateColors(mergedMantineColors),
 					...generatePrimaryColors(),
-					...generateVariantSpecificColors(mantineColors),
+					...generateVariantSpecificColors(mergedMantineColors),
 					...generateVariantSpecificPrimaryColors(),
 					...generateOtherBackgroundColors(),
 				},
 				placeholderColor: {
-					...generateColors(mantineColors),
+					...generateColors(mergedMantineColors),
 					...generatePrimaryColors(),
-					...generateVariantSpecificColors(mantineColors),
+					...generateVariantSpecificColors(mergedMantineColors),
 					...generateVariantSpecificPrimaryColors(),
 					...generateOtherTextColors(),
 				},
 				ringColor: {
-					...generateColors(mantineColors),
+					...generateColors(mergedMantineColors),
 					...generatePrimaryColors(),
-					...generateVariantSpecificColors(mantineColors),
+					...generateVariantSpecificColors(mergedMantineColors),
 					...generateVariantSpecificPrimaryColors(),
 					...generateOtherBorderColors(),
 				},
 				divideColor: {
-					...generateColors(mantineColors),
+					...generateColors(mergedMantineColors),
 					...generatePrimaryColors(),
-					...generateVariantSpecificColors(mantineColors),
+					...generateVariantSpecificColors(mergedMantineColors),
 					...generateVariantSpecificPrimaryColors(),
 					...generateOtherBorderColors(),
 				},
 				borderColor: {
-					...generateColors(mantineColors),
+					...generateColors(mergedMantineColors),
 					...generatePrimaryColors(),
-					...generateVariantSpecificColors(mantineColors),
+					...generateVariantSpecificColors(mergedMantineColors),
 					...generateVariantSpecificPrimaryColors(),
 					...generateOtherBorderColors(),
 				},


### PR DESCRIPTION
**Breaking change** to support this feature : We now pass the entire custom mantine theme to preset to access breakpoint values.

We now can use responsive tailwind classes like `lg:text-primary`