### PR TITLE
Restore Tailwind's native spacing scale

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2024 Songkeys <https://github.com/songkeys>
+Original work Copyright (c) 2024 Songkeys <https://github.com/songkeys>
+Modified work Copyright (c) 2024 William Neves
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
-# tailwind-preset-mantine
+# mantine-with-tailwind-preset-alpha
 
-[![npm version](https://img.shields.io/npm/v/tailwind-preset-mantine.svg)](https://www.npmjs.com/package/tailwind-preset-mantine)
+[![npm version](https://img.shields.io/npm/v/mantine-with-tailwind-preset-alpha.svg)](https://www.npmjs.com/package/mantine-with-tailwind-preset-alpha)
 
-A [Tailwind CSS (v4)](https://tailwindcss.com/) preset for seamless integration with [Mantine UI (v7)](https://mantine.dev/).
+A [Tailwind CSS (v4)](https://tailwindcss.com/) preset for seamless integration with [Mantine UI v8 Alpha](https://mantine.dev/).
+
+> ⚠️ **IMPORTANT:** This package is **ONLY** compatible with Mantine 8 Alpha version.
+>
+> This package is a fork of [tailwind-preset-mantine](https://github.com/songkeys/tailwind-preset-mantine) by [Songkeys](https://github.com/songkeys), adapted specifically for Mantine 8 Alpha. 
 
 ## Compatibility
 
 | Tailwind CSS Version | Mantine Version | Preset Version |
 |---------------------|-----------------|----------------|
-| v4                  | v7             | v2 (current)             |
+| v4                  | v8.0.0-alpha.x  | v0.1.0 (current) |
 | v3                  | v7             | ([v1](https://github.com/songkeys/tailwind-preset-mantine/tree/v1))* |
 
 *Note: you can still use v1 for Tailwind CSS via [`@config`](https://tailwindcss.com/docs/upgrade-guide#using-a-javascript-config-file) directive.
@@ -16,7 +20,7 @@ A [Tailwind CSS (v4)](https://tailwindcss.com/) preset for seamless integration 
 ## Installation
 
 ```bash
-npm install tailwind-preset-mantine
+npm install mantine-with-tailwind-preset-alpha
 ```
 
 ## Usage
@@ -28,7 +32,7 @@ npm install tailwind-preset-mantine
 To use the preset in your Tailwind CSS configuration, add it to the css file:
 
 ```css
-@import "tailwind-preset-mantine";
+@import "mantine-with-tailwind-preset-alpha";
 ```
 
 That's it!
@@ -57,7 +61,7 @@ Note that you don't have to import tailwind or mantine styles, this preset will 
 
 @import "@mantine/core/styles.layer.css";
 
-@import "tailwind-preset-mantine/theme.css"; /* <-- import the preset */
+@import "mantine-with-tailwind-preset-alpha/theme.css"; /* <-- import the preset */
 ```
 
 > What's `@layer`?
@@ -106,7 +110,7 @@ export default theme;
 2. Generate the CSS using our CLI:
 
 ```bash
-npx tailwind-preset-mantine theme.js -o theme.css
+npx mantine-with-tailwind-preset-alpha theme.js -o theme.css
 ```
 
 Options:
@@ -115,7 +119,7 @@ Options:
 3. Import the generated CSS file in your application:
 
 ```css
-@import "tailwind-preset-mantine";
+@import "mantine-with-tailwind-preset-alpha";
 @import "./theme.css"; /* <-- add the generated theme */
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,26 +1,26 @@
 {
-	"name": "tailwind-preset-mantine",
-	"version": "2.0.3",
-	"description": "Integrate Mantine with Tailwind CSS",
-	"keywords": ["mantine", "tailwind", "preset"],
+	"name": "mantine-with-tailwind-preset-alpha",
+	"version": "0.1.0",
+	"description": "Integrate Mantine 8 Alpha with Tailwind CSS - Fork of tailwind-preset-mantine",
+	"keywords": ["mantine", "tailwind", "preset", "mantine-alpha", "mantine-8"],
 	"files": ["src"],
-	"homepage": "https://github.com/songkeys/tailwind-preset-mantine#readme",
+	"homepage": "https://github.com/williamneves/mantine-with-tailwind-preset-alpha",
 	"bugs": {
-		"url": "https://github.com/songkeys/tailwind-preset-mantine/issues"
+		"url": "https://github.com/williamneves/mantine-with-tailwind-preset-alpha/issues"
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/songkeys/tailwind-preset-mantine.git"
+		"url": "git+https://github.com/williamneves/mantine-with-tailwind-preset-alpha.git"
 	},
 	"license": "MIT",
-	"author": "Songkeys",
+	"author": "William Neves",
 	"main": "src/index.css",
 	"exports": {
 		".": "./src/index.css",
 		"./theme.css": "./src/theme.css"
 	},
 	"bin": {
-		"tailwind-preset-mantine": "./src/cli.js"
+		"mantine-with-tailwind-preset-alpha": "./src/cli.js"
 	},
 	"scripts": {
 		"lint": "biome check .",
@@ -30,11 +30,11 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",
-		"@mantine/core": "^7.16.2",
+		"@mantine/core": "^8.0.0-alpha.1",
 		"bumpp": "^10.0.1"
 	},
 	"peerDependencies": {
-		"@mantine/core": "^7",
+		"@mantine/core": "^8.0.0-alpha.1",
 		"tailwindcss": "^4"
 	},
 	"packageManager": "pnpm@9.15.4",

--- a/src/generate.js
+++ b/src/generate.js
@@ -73,7 +73,6 @@ ${isDefault ? '@custom-variant dark (&:where([data-mantine-color-scheme="dark"],
   --spacing-md: var(--mantine-spacing-md);
   --spacing-lg: var(--mantine-spacing-lg);
   --spacing-xl: var(--mantine-spacing-xl);
-  --spacing: var(--mantine-spacing-md);
 
   /* container */
   /* TODO: */

--- a/src/index.css
+++ b/src/index.css
@@ -54,7 +54,6 @@
   --spacing-md: var(--mantine-spacing-md);
   --spacing-lg: var(--mantine-spacing-lg);
   --spacing-xl: var(--mantine-spacing-xl);
-  --spacing: var(--mantine-spacing-md);
 
   /* container */
   /* TODO: */

--- a/src/theme.css
+++ b/src/theme.css
@@ -46,7 +46,6 @@
   --spacing-md: var(--mantine-spacing-md);
   --spacing-lg: var(--mantine-spacing-lg);
   --spacing-xl: var(--mantine-spacing-xl);
-  --spacing: var(--mantine-spacing-md);
 
   /* container */
   /* TODO: */


### PR DESCRIPTION
## Problem
The preset currently overwrites Tailwind's default spacing system by mapping the base spacing unit to Mantine's `--mantine-spacing-md` (1rem). This breaks the expected behavior of Tailwind's utility classes:

- Standard Tailwind: `p-1` = 0.25rem, `p-2` = 0.5rem, `p-3` = 0.75rem
- Current preset: `p-1` = 1rem, `p-2` = 2rem, `p-3` = 3rem

This large jump between spacing increments makes it difficult to create fine-tuned layouts and breaks compatibility with existing Tailwind projects.

## Solution
This PR removes the `--spacing: var(--mantine-spacing-md)` line from all relevant files, restoring Tailwind's native spacing scale with 0.25rem increments while preserving all other Mantine design tokens.

## Benefits
- Maintains backward compatibility with standard Tailwind spacing
- Allows for more precise layout control with finer spacing increments
- Reduces friction for teams migrating existing Tailwind projects
- Still provides access to Mantine's named spacing variables when needed

This change ensures the best of both worlds: Mantine's design system with Tailwind's intuitive spacing scale.
