### PR TITLE
Restore Tailwind's native spacing scale

### DIFF
--- a/src/generate.js
+++ b/src/generate.js
@@ -73,7 +73,6 @@ ${isDefault ? '@custom-variant dark (&:where([data-mantine-color-scheme="dark"],
   --spacing-md: var(--mantine-spacing-md);
   --spacing-lg: var(--mantine-spacing-lg);
   --spacing-xl: var(--mantine-spacing-xl);
-  --spacing: var(--mantine-spacing-md);
 
   /* container */
   /* TODO: */

--- a/src/index.css
+++ b/src/index.css
@@ -54,7 +54,6 @@
   --spacing-md: var(--mantine-spacing-md);
   --spacing-lg: var(--mantine-spacing-lg);
   --spacing-xl: var(--mantine-spacing-xl);
-  --spacing: var(--mantine-spacing-md);
 
   /* container */
   /* TODO: */

--- a/src/theme.css
+++ b/src/theme.css
@@ -46,7 +46,6 @@
   --spacing-md: var(--mantine-spacing-md);
   --spacing-lg: var(--mantine-spacing-lg);
   --spacing-xl: var(--mantine-spacing-xl);
-  --spacing: var(--mantine-spacing-md);
 
   /* container */
   /* TODO: */


### PR DESCRIPTION
## Problem
The preset currently overwrites Tailwind's default spacing system by mapping the base spacing unit to Mantine's `--mantine-spacing-md` (1rem). This breaks the expected behavior of Tailwind's utility classes:

- Standard Tailwind: `p-1` = 0.25rem, `p-2` = 0.5rem, `p-3` = 0.75rem
- Current preset: `p-1` = 1rem, `p-2` = 2rem, `p-3` = 3rem

This large jump between spacing increments makes it difficult to create fine-tuned layouts and breaks compatibility with existing Tailwind projects.

## Solution
This PR removes the `--spacing: var(--mantine-spacing-md)` line from all relevant files, restoring Tailwind's native spacing scale with 0.25rem increments while preserving all other Mantine design tokens.

## Benefits
- Maintains backward compatibility with standard Tailwind spacing
- Allows for more precise layout control with finer spacing increments
- Reduces friction for teams migrating existing Tailwind projects
- Still provides access to Mantine's named spacing variables when needed

This change ensures the best of both worlds: Mantine's design system with Tailwind's intuitive spacing scale.
