### PR TITLE
docs: replace "or" symbol to show Mantine v8 compat in table

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 [![npm version](https://img.shields.io/npm/v/tailwind-preset-mantine.svg)](https://www.npmjs.com/package/tailwind-preset-mantine)
 
-A [Tailwind CSS (v4)](https://tailwindcss.com/) preset for seamless integration with [Mantine UI (v7 || v8)](https://mantine.dev/).
+A [Tailwind CSS (v4)](https://tailwindcss.com/) preset for seamless integration with [Mantine UI (v7 or v8)](https://mantine.dev/).
 
 ## Compatibility
 
 | Tailwind CSS Version | Mantine Version | Preset Version |
 |---------------------|-----------------|----------------|
-| v4                  | v7 || v8        | v2 (current)             |
-| v3                  | v7 || v8        | ([v1](https://github.com/songkeys/tailwind-preset-mantine/tree/v1))* |
+| v4                  | v7 or v8        | v2 (current)             |
+| v3                  | v7 or v8        | ([v1](https://github.com/songkeys/tailwind-preset-mantine/tree/v1))* |
 
 *Note: you can still use v1 for Tailwind CSS V4 via [`@config`](https://tailwindcss.com/docs/upgrade-guide#using-a-javascript-config-file) directive.
 


### PR DESCRIPTION
The README wasn't showing that it was compatible with Mantine v8 when the "or" symbol was used in the Markdown table.

**Before**
<img width="590" height="385" alt="Screenshot 2025-08-27 at 9 09 31 PM" src="https://github.com/user-attachments/assets/13a9eb71-fda7-4353-b9b8-923bd2135353" />
