### PR TITLE
feat: add missing color-text variable

### DIFF
--- a/src/generate.js
+++ b/src/generate.js
@@ -66,6 +66,7 @@ ${
   --color-black: var(--mantine-color-black);
   --color-bright: var(--mantine-color-bright);
   --color-body: var(--mantine-color-body);
+  --color-text: var(--mantine-color-text);
   --color-error: var(--mantine-color-error);
   --color-placeholder: var(--mantine-color-placeholder);
   --color-anchor: var(--mantine-color-anchor);

--- a/src/index.css
+++ b/src/index.css
@@ -45,6 +45,7 @@
 	--color-black: var(--mantine-color-black);
 	--color-bright: var(--mantine-color-bright);
 	--color-body: var(--mantine-color-body);
+  --color-text: var(--mantine-color-text);
 	--color-error: var(--mantine-color-error);
 	--color-placeholder: var(--mantine-color-placeholder);
 	--color-anchor: var(--mantine-color-anchor);

--- a/src/theme.css
+++ b/src/theme.css
@@ -38,6 +38,7 @@
 	--color-black: var(--mantine-color-black);
 	--color-bright: var(--mantine-color-bright);
 	--color-body: var(--mantine-color-body);
+  --color-text: var(--mantine-color-text);
 	--color-error: var(--mantine-color-error);
 	--color-placeholder: var(--mantine-color-placeholder);
 	--color-anchor: var(--mantine-color-anchor);


### PR DESCRIPTION
Add missing `--mantine-color-text` variable.
closes https://github.com/songkeys/tailwind-preset-mantine/issues/31