### PR TITLE
Ignore stylesheet and asset imports when loading theme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ export default theme;
 npx tailwind-preset-mantine theme.js -o theme.css
 ```
 
+The CLI ignores imported stylesheet and asset files in the theme import graph, so `theme.ts` can safely import CSS modules, Sass files, images, fonts, or colocated `.tsx` helper modules that reference those files.
+
 Options:
 - `-o, --output`: Output file name/location (default: "theme.css")
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"lint": "biome check .",
 		"lint:fix": "biome check . --write",
 		"release": "bumpp",
-		"test": "node --test"
+		"test": "node --test test/cli.test.js"
 	},
 	"dependencies": {
 		"tsx": "^4.21.0"

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,12 +1,95 @@
 #!/usr/bin/env node
 import "tsx";
 import { writeFile } from "node:fs/promises";
+import * as nodeModule from "node:module";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { parseArgs } from "node:util";
 import { generateTheme } from "./generate.js";
 
 const pwd = process.cwd();
+const STYLE_EXTENSIONS = [
+	".css",
+	".scss",
+	".sass",
+	".less",
+	".styl",
+	".stylus",
+];
+const ASSET_EXTENSIONS = [
+	".svg",
+	".png",
+	".jpg",
+	".jpeg",
+	".gif",
+	".webp",
+	".avif",
+	".ico",
+	".bmp",
+	".tiff",
+	".woff",
+	".woff2",
+	".ttf",
+	".otf",
+	".eot",
+];
+
+function normalizeSpecifier(specifier) {
+	return specifier.split("?")[0]?.split("#")[0] ?? specifier;
+}
+
+function matchesExtension(specifier, extensions) {
+	const normalizedSpecifier = normalizeSpecifier(specifier);
+	return extensions.some((extension) =>
+		normalizedSpecifier.endsWith(extension),
+	);
+}
+
+function ignoreNonCodeImports() {
+	// Theme files often pull in styling and asset files, but generation only needs theme tokens.
+	const require = nodeModule.createRequire(import.meta.url);
+	const extensions = require.extensions;
+
+	for (const extension of STYLE_EXTENSIONS) {
+		if (!extensions[extension]) {
+			extensions[extension] = (module) => {
+				module.exports = {};
+			};
+		}
+	}
+
+	for (const extension of ASSET_EXTENSIONS) {
+		if (!extensions[extension]) {
+			extensions[extension] = (module) => {
+				module.exports = "__tailwind_preset_mantine_asset__";
+			};
+		}
+	}
+
+	if (typeof nodeModule.registerHooks === "function") {
+		nodeModule.registerHooks({
+			load(url, context, nextLoad) {
+				if (matchesExtension(url, STYLE_EXTENSIONS)) {
+					return {
+						format: "module",
+						shortCircuit: true,
+						source: "export default {};",
+					};
+				}
+
+				if (matchesExtension(url, ASSET_EXTENSIONS)) {
+					return {
+						format: "module",
+						shortCircuit: true,
+						source: 'export default "__tailwind_preset_mantine_asset__";',
+					};
+				}
+
+				return nextLoad(url, context);
+			},
+		});
+	}
+}
 
 // Define CLI options
 const options = {
@@ -35,6 +118,8 @@ try {
 
 	// Convert file path to URL for ESM import compatibility
 	const themeURL = pathToFileURL(themePath);
+
+	ignoreNonCodeImports();
 
 	// Execute the theme file content to get the theme object
 	const themeModule = await import(themeURL);

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -97,6 +97,18 @@ test("processes custom TS theme", async () => {
 	await testThemeGeneration(inputPath, "custom-theme-ts-output.css");
 });
 
+// Test: CLI should ignore stylesheet imports in the theme import graph
+test("processes theme files that import stylesheets", async () => {
+	const inputPath = join(FIXTURES_DIR, "theme-with-css-import.ts");
+	await testThemeGeneration(inputPath, "theme-with-css-import-output.css");
+});
+
+// Test: CLI should ignore asset imports in the theme import graph
+test("processes theme files that import assets through tsx modules", async () => {
+	const inputPath = join(FIXTURES_DIR, "theme-with-assets-import.ts");
+	await testThemeGeneration(inputPath, "theme-with-assets-import-output.css");
+});
+
 // Test: CLI should process CJS theme
 test("processes CJS theme", async () => {
 	const inputPath = join(FIXTURES_DIR, "cjs-theme.cjs");

--- a/test/fixtures/styles.d.ts
+++ b/test/fixtures/styles.d.ts
@@ -1,0 +1,104 @@
+declare module "*.css" {
+	const classes: Record<string, string>;
+	export default classes;
+}
+
+declare module "*.scss" {
+	const classes: Record<string, string>;
+	export default classes;
+}
+
+declare module "*.sass" {
+	const classes: Record<string, string>;
+	export default classes;
+}
+
+declare module "*.less" {
+	const classes: Record<string, string>;
+	export default classes;
+}
+
+declare module "*.styl" {
+	const classes: Record<string, string>;
+	export default classes;
+}
+
+declare module "*.stylus" {
+	const classes: Record<string, string>;
+	export default classes;
+}
+
+declare module "*.svg" {
+	const assetUrl: string;
+	export default assetUrl;
+}
+
+declare module "*.png" {
+	const assetUrl: string;
+	export default assetUrl;
+}
+
+declare module "*.jpg" {
+	const assetUrl: string;
+	export default assetUrl;
+}
+
+declare module "*.jpeg" {
+	const assetUrl: string;
+	export default assetUrl;
+}
+
+declare module "*.gif" {
+	const assetUrl: string;
+	export default assetUrl;
+}
+
+declare module "*.webp" {
+	const assetUrl: string;
+	export default assetUrl;
+}
+
+declare module "*.avif" {
+	const assetUrl: string;
+	export default assetUrl;
+}
+
+declare module "*.ico" {
+	const assetUrl: string;
+	export default assetUrl;
+}
+
+declare module "*.bmp" {
+	const assetUrl: string;
+	export default assetUrl;
+}
+
+declare module "*.tiff" {
+	const assetUrl: string;
+	export default assetUrl;
+}
+
+declare module "*.woff" {
+	const assetUrl: string;
+	export default assetUrl;
+}
+
+declare module "*.woff2" {
+	const assetUrl: string;
+	export default assetUrl;
+}
+
+declare module "*.ttf" {
+	const assetUrl: string;
+	export default assetUrl;
+}
+
+declare module "*.otf" {
+	const assetUrl: string;
+	export default assetUrl;
+}
+
+declare module "*.eot" {
+	const assetUrl: string;
+	export default assetUrl;
+}

--- a/test/fixtures/theme-font.woff2
+++ b/test/fixtures/theme-font.woff2
@@ -1,0 +1,1 @@
+dummy-font-data

--- a/test/fixtures/theme-logo.svg
+++ b/test/fixtures/theme-logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <circle cx="8" cy="8" r="6" fill="currentColor" />
+</svg>

--- a/test/fixtures/theme-with-assets-entry.tsx
+++ b/test/fixtures/theme-with-assets-entry.tsx
@@ -1,0 +1,24 @@
+import { createTheme } from "@mantine/core";
+import brandFontUrl from "./theme-font.woff2";
+import brandLogoUrl from "./theme-logo.svg";
+
+if (!brandFontUrl || !brandLogoUrl) {
+	throw new Error("Expected asset imports to be stubbed");
+}
+
+export const themeWithAssets = createTheme({
+	colors: {
+		forest: [
+			"#eefbf1",
+			"#def3e2",
+			"#bde7c4",
+			"#98daa3",
+			"#79d08a",
+			"#64ca78",
+			"#57c56d",
+			"#45ad5b",
+			"#3a9a4f",
+			"#2d8741",
+		],
+	},
+});

--- a/test/fixtures/theme-with-assets-import.ts
+++ b/test/fixtures/theme-with-assets-import.ts
@@ -1,0 +1,3 @@
+import { themeWithAssets } from "./theme-with-assets-entry.tsx";
+
+export default themeWithAssets;

--- a/test/fixtures/theme-with-css-import.module.css
+++ b/test/fixtures/theme-with-css-import.module.css
@@ -1,0 +1,3 @@
+.root {
+	background: var(--mantine-color-brand-filled);
+}

--- a/test/fixtures/theme-with-css-import.ts
+++ b/test/fixtures/theme-with-css-import.ts
@@ -1,0 +1,26 @@
+import { createTheme } from "@mantine/core";
+import buttonStyles from "./theme-with-css-import.module.css";
+
+const theme = createTheme({
+	colors: {
+		brand: [
+			"#fff1f2",
+			"#ffe4e6",
+			"#fecdd3",
+			"#fda4af",
+			"#fb7185",
+			"#f43f5e",
+			"#e11d48",
+			"#be123c",
+			"#9f1239",
+			"#881337",
+		],
+	},
+	components: {
+		Button: {
+			classNames: buttonStyles,
+		},
+	},
+});
+
+export default theme;

--- a/test/fixtures/tsconfig.json
+++ b/test/fixtures/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"compilerOptions": {
+		"allowImportingTsExtensions": true,
+		"jsx": "react-jsx",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"target": "ES2022",
+		"noEmit": true
+	},
+	"include": ["./**/*.ts", "./**/*.tsx", "./**/*.d.ts"]
+}


### PR DESCRIPTION
## Summary
This updates the CLI so it can load theme files even when the import graph includes non-code files.

## What changed
- ignore stylesheet imports when loading theme modules
- ignore common asset imports like images and font files
- add fixture coverage for CSS modules and for a `.tsx` helper that imports an SVG and a font
- narrow the test command so files under `test/fixtures` are not treated as test entrypoints
- add fixture-local TypeScript config and ambient module declarations so editor diagnostics stay stable

## Why
The generator only needs the resolved theme object, but real theme graphs can pull in colocated component helpers that import CSS modules, images, or fonts. Those imports were causing module resolution to fail before generation even started.

## Validation
- `pnpm test`
- `pnpm lint`

Fixes #17