### PR TITLE
fix(theme-loader): use file URL for --import on Windows

### DIFF
--- a/src/core/theme-loader.js
+++ b/src/core/theme-loader.js
@@ -9,6 +9,7 @@ const THIS_FILE = fileURLToPath(import.meta.url);
 const CHILD_RESULT_MARKER = "__TWPM_THEME_RESULT__";
 const require = nodeModule.createRequire(import.meta.url);
 const TSX_LOADER_PATH = require.resolve("tsx");
+const TSX_LOADER_URL = pathToFileURL(TSX_LOADER_PATH).href;
 const STYLE_EXTENSIONS = [
 	".css",
 	".scss",
@@ -139,7 +140,7 @@ async function loadThemeFromFileInProcess(themePath, baseDir = process.cwd()) {
 export async function loadThemeFromFile(themePath, baseDir = process.cwd()) {
 	const { stdout } = await execFile(
 		process.execPath,
-		["--import", TSX_LOADER_PATH, THIS_FILE, "--child", themePath, baseDir],
+		["--import", TSX_LOADER_URL, THIS_FILE, "--child", themePath, baseDir],
 		{
 			cwd: resolve(baseDir),
 			maxBuffer: 5 * 1024 * 1024,


### PR DESCRIPTION
## Problem

On Windows, `npm run dev` (and anything else that loads the Mantine theme through the preset) was failing with:

`Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: ... Received protocol 'c:'`

The child process is spawned with something like:

`node --import C:\...\node_modules\tsx\dist\loader.mjs ...`

Node treats that Windows path as a broken URL scheme instead of a module specifier, so the loader never runs.

## Change

Resolve the tsx loader path as usual, but pass `pathToFileURL(loaderPath).href` to `--import` so it’s a valid `file://` URL on Windows. The script path (`THIS_FILE`) is unchanged so the existing `process.argv[1] === THIS_FILE` check still works.

## How I tested

- Windows 10, Node 22+
- Ran a Next app using `@import "./theme.css"` / the preset’s PostCSS pipeline — dev server and `/` load without the previous error.
